### PR TITLE
Fix blank page by lazy loading heavy modules

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -24,6 +24,7 @@ interface AppState {
   setLogs: (logs: string[]) => void;
   appendLog: (log: string) => void;
   setWarnings: (warnings: string[]) => void;
+  appendWarning: (warning: string) => void;
   setLoading: (loading: boolean) => void;
   setProgress: (progress: number) => void;
   setLineCounts: (counts: { commande?: number; amalgame?: number }) => void;
@@ -65,6 +66,10 @@ export const useAppStore = create<AppState>((set) => ({
       logs: [...state.logs, log]
     })),
   setWarnings: (warnings) => set({ warnings }),
+  appendWarning: (warning) =>
+    set((state) => ({
+      warnings: [...state.warnings, warning]
+    })),
   setLoading: (loading) => set({ loading }),
   setProgress: (progress) => set({ progress }),
   setLineCounts: (counts) =>


### PR DESCRIPTION
## Summary
- Lazy-load the PDF and spreadsheet parsers inside the dropzone so the UI renders even when those bundles are unavailable at startup
- Defer CSV/PDF export helpers and surface any export failure as an in-app warning instead of crashing the page
- Extend the Zustand store with an `appendWarning` helper to reuse warning handling logic

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fnode)*

------
https://chatgpt.com/codex/tasks/task_e_68d3bb52f75c83318518a4883a7ed539