### PR TITLE
Fix Vite base path for static hosting

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 
 export default defineConfig({
+  base: './',
   plugins: [react()],
   build: {
     target: 'esnext'


### PR DESCRIPTION
## Summary
- add a relative base path in the Vite config so assets load from subdirectories during static hosting

## Testing
- npm install *(fails: registry access is blocked in the execution environment)*
- npm run build *(not run; depends on npm install)*

------
https://chatgpt.com/codex/tasks/task_e_68d3bf396ce0833183fcd981ae0019e4