### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,51 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+
+      - name: Upload build output
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ npm run dev
 
 Puis ouvrez http://localhost:5173/ dans votre navigateur. L'outil peut également être déployé en statique via `npm run build`.
 
+## Déploiement
+
+- Pousser sur `main` → site en ligne automatiquement.
+
 ## Format attendu
 
 - Chaque fichier doit être un CSV (ou TSV) avec prénom et nom dans les deux premières colonnes.

--- a/src/types/papaparse.d.ts
+++ b/src/types/papaparse.d.ts
@@ -1,0 +1,39 @@
+/* Minimal type declarations for papaparse usage in this project. */
+declare module 'papaparse' {
+  export type ParseError = {
+    type: string;
+    code: string;
+    message: string;
+    row: number;
+  };
+
+  export type ParseMeta = {
+    aborted: boolean;
+    cursor: number;
+    delimiter: string;
+    linebreak: string;
+    truncated: boolean;
+    fields?: string[];
+  };
+
+  export type ParseResult<T> = {
+    data: T[];
+    errors: ParseError[];
+    meta: ParseMeta;
+  };
+
+  export type ParseConfig<T> = {
+    header?: boolean;
+    skipEmptyLines?: boolean | 'greedy';
+    transformHeader?: (header: string) => string;
+    complete?: (results: ParseResult<T>, file?: File) => void;
+    error?: (error: ParseError) => void;
+  };
+
+  export interface PapaStatic {
+    parse<T>(data: string | File | Blob, config?: ParseConfig<T>): ParseResult<T>;
+  }
+
+  const Papa: PapaStatic;
+  export default Papa;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 
 export default defineConfig({
-  base: './',
+  base: '/CheckBadges/',
   plugins: [react()],
   build: {
     target: 'esnext'


### PR DESCRIPTION
## Summary
- set the Vite base path to match the GitHub Pages repository name
- add a GitHub Actions workflow that builds the project and publishes `dist/` to Pages on pushes to `main`
- document the automatic deployment and add minimal `papaparse` type declarations required for the build

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d3c80cab1c83319d5d80153f6b001a