### PR TITLE
fix: avoid blank page when opening the build locally

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,10 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 
+const isGitHubPages = process.env.GITHUB_ACTIONS === 'true';
+
 export default defineConfig({
-  base: '/CheckBadges/',
+  base: isGitHubPages ? '/CheckBadges/' : './',
   plugins: [react()],
   build: {
     target: 'esnext'


### PR DESCRIPTION
## Summary
- detect when the build runs in GitHub Actions to keep the /CheckBadges/ base for deployment
- use a relative base path for local builds so the generated index.html can load its assets without a web server

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3cc79ab28833188fbf10e285983a8