### PR TITLE
feat: enrich comparison results with filters and export

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -113,17 +113,39 @@ body {
 }
 
 .summary__item {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 8px;
   padding: 8px 12px;
   border-radius: 12px;
   border: 1px solid #e2e8f0;
   background: #f8fafc;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
 }
 
 .summary__item strong {
   font-size: 1.1rem;
+}
+
+.summary__item:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
+}
+
+.summary__item:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 3px;
+}
+
+.summary__item[aria-pressed='false'] {
+  opacity: 0.45;
+}
+
+.summary__item[aria-pressed='false']:hover {
+  opacity: 0.65;
 }
 
 .status {
@@ -164,6 +186,80 @@ body {
   border: 1px solid #e2e8f0;
   overflow: hidden;
   overflow-x: auto;
+}
+
+.panel__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.panel__actions-buttons {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.panel__info--muted {
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
+.panel__info--success {
+  color: #166534;
+  font-weight: 600;
+}
+
+.action-button {
+  border: none;
+  background: #1d4ed8;
+  color: #ffffff;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 10px 18px;
+  cursor: pointer;
+  transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.action-button:hover:not(:disabled) {
+  background: #1e40af;
+  box-shadow: 0 8px 20px rgba(30, 64, 175, 0.25);
+  transform: translateY(-1px);
+}
+
+.action-button:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
+.action-button:disabled {
+  background: #dbeafe;
+  color: #64748b;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.reset-button {
+  border: none;
+  background: transparent;
+  color: #2563eb;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  padding: 0;
+}
+
+.reset-button:disabled {
+  color: #94a3b8;
+  cursor: not-allowed;
+}
+
+.reset-button:not(:disabled):hover {
+  text-decoration: underline;
 }
 
 table {


### PR DESCRIPTION
## Summary
- add status filters with toggles, reset, and row counters to the comparison results
- expose dataset origins and enable CSV export of detected anomalies
- refresh table and control styling for interactive filters and actions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3d5f2ffc883319f7610e6e066ab23