### PR TITLE
Drop CSV upload support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ en place dans un environnement verrouillé. Cette nouvelle mouture mise sur :
 
 - une base React + Vite très légère ;
 - un seul point d'entrée (`src/App.tsx`) lisible et facilement extensible ;
-- l'utilisation de CSV standards ou de PDF textuels (accents et casse ignorés automatiquement) ;
+- l'utilisation exclusive de PDF textuels (accents et casse ignorés automatiquement) ;
 - aucune dépendance lourde ni traitement asynchrone côté serveur.
 
 ## Installation et lancement
@@ -29,14 +29,14 @@ Puis ouvrez http://localhost:5173/ dans votre navigateur. L'outil peut égalemen
 
 ## Format attendu
 
-- Chaque fichier peut être un CSV (ou TSV) avec prénom et nom dans les deux premières colonnes, ou un PDF textuel contenant un tableau avec ces colonnes.
+- Chaque fichier doit être un PDF textuel contenant un tableau avec les colonnes prénom et nom.
 - Les en-têtes sont recommandés. Les accents, espaces superflus et différences de casse sont automatiquement ignorés.
-- Vous pouvez exporter depuis Excel/Sheets ("Enregistrer sous… CSV"), tout CRM générant un tableau texte, ou déposer directement le bon de commande PDF si les noms y figurent dans un tableau.
+- Exportez ou générez un PDF depuis votre CRM ou l'outil de production des badges : les noms doivent être présents dans un tableau accessible.
 
 ## Fonctionnement
 
 1. Importez le bon de commande et la liste de badges grâce aux deux champs de sélection.
-2. L'application analyse localement les fichiers (bibliothèque `papaparse`).
+2. L'application analyse localement le texte des PDF pour identifier les prénoms et noms.
 3. Une normalisation simple (suppression des accents, mise en minuscules) permet de comparer les noms.
 4. Les résultats sont affichés dans un tableau unique avec les compteurs suivants :
    - **Manquant** : présent dans la commande mais absent des badges ;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "checkbadges",
       "version": "0.1.0",
       "dependencies": {
-        "papaparse": "^5.4.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -1109,12 +1108,6 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
-    },
-    "node_modules/papaparse": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
-      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
-      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "papaparse": "^5.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
## Summary
- remove CSV parsing logic and restrict uploads to PDFs with user feedback
- update documentation to describe a PDF-only workflow
- drop the papaparse dependency now that CSV support is gone

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3dcc5dcd483318b0b39dcf06f9c19