### PR TITLE
Fix blank page on GitHub Pages deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,10 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 
-const isGitHubPages = process.env.GITHUB_ACTIONS === 'true';
-
 export default defineConfig({
-  base: isGitHubPages ? '/CheckBadges/' : './',
+  // Always use relative asset URLs so the app works whether it is served from
+  // the repository subpath on GitHub Pages or from any other base URL.
+  base: './',
   plugins: [react()],
   build: {
     // Target a broadly supported ECMAScript version to avoid syntax errors (blank page)


### PR DESCRIPTION
## Summary
- force Vite to emit relative asset URLs so the app works from any base path

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3e75739ac833187113f25eaf873b1